### PR TITLE
商品一覧表示機能実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,6 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index] 
 
   def index
-    @items = Item.all
     @items = Item.order("created_at DESC")
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,8 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index] 
 
   def index
-    @items = Area.order("created_at DESC")
+    @items = Item.all
+    @items = Item.order("created_at DESC")
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,6 +3,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index] 
 
   def index
+    @items = Item
     @items = Item.order("created_at DESC")
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -3,7 +3,6 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, except: [:index] 
 
   def index
-    @items = Item
     @items = Item.order("created_at DESC")
   end
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,7 +126,7 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <% @items.each do |item| %>
+    <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
@@ -155,7 +155,7 @@
         </div>
         <% end %>
       </li>
-      <% end %>
+    <% end %>
 
     <% if @items == nil %>
       <li class='list'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,25 +126,27 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
+        <%# if @items = nil %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
+        <%# end %>
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.title %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= '配送料負担' %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -153,10 +155,9 @@
         </div>
         <% end %>
       </li>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <% end %>
 
-      <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+    <% if @items == nil %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -174,11 +175,9 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# /商品がない場合のダミー %>
+    <% end %>
     </ul>
   </div>
-  <%# /商品一覧 %>
 </div>
 <%= link_to new_item_path, class: 'purchase-btn' do %>
   <span class='purchase-btn-text'>出品する</span>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -146,7 +146,7 @@
             <%= item.title %>
           </h3>
           <div class='item-price'>
-            <span><%= item.price %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.freight %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -126,7 +126,7 @@
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
   <ul class='item-lists'>
 
-  <% if @items！= nil %>
+  <% if @items != nil %>
     <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
@@ -134,11 +134,9 @@
           <%= image_tag item.image, class: "item-img" %>
 
           <%# 商品が売れていればsold outを表示しましょう %>
-        <%# if @items = nil %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
-        <%# end %>
           <%# //商品が売れていればsold outを表示しましょう %>
 
         </div>
@@ -157,8 +155,8 @@
         <% end %>
       </li>
     <% end %>
-
-  <% else %>
+  <% end %>
+  <% if @items.blank?%>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -124,8 +124,9 @@
   <div class='item-contents'>
     <h2 class='title'>ピックアップカテゴリー</h2>
     <%= link_to '新規投稿商品', "#", class: "subtitle" %>
-    <ul class='item-lists'>
+  <ul class='item-lists'>
 
+  <% if @items！= nil %>
     <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
@@ -146,7 +147,7 @@
             <%= item.title %>
           </h3>
           <div class='item-price'>
-            <span><%= item.price %>円<br><%= item.freight %></span>
+            <span><%= item.price %>円<br><%= item.freight.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
@@ -157,7 +158,7 @@
       </li>
     <% end %>
 
-    <% if @items == nil %>
+  <% else %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
@@ -175,10 +176,13 @@
         </div>
         <% end %>
       </li>
-    <% end %>
-    </ul>
+  <% end %>
+
+  </ul>
+
   </div>
 </div>
+
 <%= link_to new_item_path, class: 'purchase-btn' do %>
   <span class='purchase-btn-text'>出品する</span>
   <%= image_tag 'icon_camera.png' , size: '185x50' ,class: "purchase-btn-icon" %>


### PR DESCRIPTION
WHAT

商品を出品した段階でトップページに当たる部分に表示させる機能を実装しました。
また、出品した物が新しい順に右から並ぶようにしました

WHY

出品された商品がデータベースの中にいるのを表示させなければ利用者は購入、閲覧することができないから

テスト前　https://gyazo.com/d3a182ccd7140b57165ca1f257a3a369
テスト　https://gyazo.com/d3a182ccd7140b57165ca1f257a3a369
